### PR TITLE
Missing trailing forward slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google Cloud Redis for PHP
 
-> Idiomatic PHP client for [Google Cloud Redis](https://cloud.google.com/memorystore).
+> Idiomatic PHP client for [Google Cloud Redis](https://cloud.google.com/memorystore/).
 
 [![Latest Stable Version](https://poser.pugx.org/google/cloud-redis/v/stable)](https://packagist.org/packages/google/cloud-redis) [![Packagist](https://img.shields.io/packagist/dm/google/cloud-redis.svg)](https://packagist.org/packages/google/cloud-redis)
 


### PR DESCRIPTION
Missing trailing forward slash "Google Cloud Redis" URL

**PLEASE READ THIS ENTIRE MESSAGE**

Hello, and thank you for your contribution! Please note that this repository is
a read-only split of `GoogleCloudPlatform/google-cloud-php`. As such, we are
unable to accept pull requests to this repository.

We welcome your pull request and would be happy to consider it for inclusion in
our library if you follow these steps:

* Clone the parent client library repository:

```sh
$ git clone git@github.com:GoogleCloudPlatform/google-cloud-php.git
```

* Move your changes into the correct location in that library. Library code
belongs in `Redis/src`, and tests in `Redis/tests`.

* Push the changes in a new branch to a fork, and open a new pull request
[here](https://github.com/GoogleCloudPlatform/google-cloud-php).

Thanks again, and we look forward to seeing your proposed change!

The Google Cloud PHP team
